### PR TITLE
Nearest neighbours

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,12 +15,9 @@
 
 A fast ball tree implementation for three dimensional (weighted) data with an
 Euclidean distance norm. The base implementation is in `C` and there is a
-wrapper for `Python`.
-
-The tree is optimised towards spatial correlation function calculations since
-the query routines are geared towards range queries, i.e. counting pairs with a
-given (range of) separations. Fixed number nearest neighbour search is currently
-not implemented.
+wrapper for `Python`. The tree is optimised towards spatial correlation function
+calculations since it provides fast counting routinge, e.g. by implementing a
+dualtree query algorithm.
 
 - Code: https://github.com/jlvdb/balltree.git
 - Docs: https://balltree.readthedocs.io/

--- a/TODO
+++ b/TODO
@@ -1,0 +1,2 @@
+add test for each method with chaining to check for memory leaks
+reimplement queue passing to improve nearest neighbour search for multiple inputs in python

--- a/TODO
+++ b/TODO
@@ -1,2 +1,0 @@
-add test for each method with chaining to check for memory leaks
-reimplement queue passing to improve nearest neighbour search for multiple inputs in python

--- a/balltree/__init__.py
+++ b/balltree/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.1"
+__version__ = "1.1.0"
 
 from .angulartree import AngularTree
 from .balltree import BallTree, default_leafsize as _df

--- a/balltree/angulartree.py
+++ b/balltree/angulartree.py
@@ -74,11 +74,12 @@ class AngularTree(BallTree):
             np.transpose([data["x"], data["y"], data["z"]])
         )
 
-        dtype = [("ra", "f8"), ("dec", "f8"), ("weight", "f8")]
+        dtype = [("ra", "f8"), ("dec", "f8"), ("weight", "f8"), ("index", "i8")]
         array = np.empty(len(data), dtype=dtype)
         array["ra"] = radec[:, 0]
         array["dec"] = radec[:, 1]
         array["weight"] = data["weight"]
+        array["index"] = data["index"]
         return array
 
     @property
@@ -102,7 +103,7 @@ class AngularTree(BallTree):
         center = coord.angular_to_euclidean(self.center)[0]
         radec_flat = self.data.view("f8")
         shape = (self.num_points, -1)
-        xyz = coord.angular_to_euclidean(radec_flat.reshape(shape)[:, :-1])
+        xyz = coord.angular_to_euclidean(radec_flat.reshape(shape)[:, :-2])
         # compute the maximum distance from the center project one the sphere
         diff = xyz - center[np.newaxis, :]
         dist = np.sqrt(np.sum(diff**2, axis=1))

--- a/balltree/angulartree.py
+++ b/balltree/angulartree.py
@@ -51,10 +51,10 @@ class AngularTree(BallTree):
         Build a new AngularTree instance from randomly generated points.
         
         The (ra, dec) coordinates are generated uniformly in the interval
-        [`ra_min`, `ra_max`) and [`dec_min`, `dec_max`), respectively. `size`
-        controlls the number of points generated. The optional `leafsize`
-        determines when the tree query algorithms switch from traversal to brute
-        force.
+        [``ra_min``, ``ra_max``) and [``dec_min``, ``dec_max``), respectively.
+        ``size`` controlls the number of points generated. The optional
+        ``leafsize`` determines when the tree query algorithms switch from
+        traversal to brute force.
         """
         ((x_min, y_min),) = coord.angular_to_cylinder([ra_min, dec_min])
         ((x_max, y_max),) = coord.angular_to_cylinder([ra_max, dec_max])
@@ -121,14 +121,44 @@ class AngularTree(BallTree):
         """
         Collect the meta data of all tree nodes in a numpy array.
 
-        The array fields record `depth` (starting from the root node),
-        `num_points`, `sum_weight`, `x`, `y`, `z` (node center) and node `radius`.
+        The array fields record ``depth`` (starting from the root node),
+        ``num_points``, ``sum_weight``, ``x``, ``y``, ``z`` (node center) and
+        node ``radius``.
 
         .. Note::
             The node coordinates and radius are currently not converted to
             anlges.
         """
         return super().get_node_data()
+
+    def nearest_neighbours(self, radec, k, max_ang=-1.0) -> NDArray:
+        """
+        Query a fixed number of nearest neighbours.
+
+        The query point(s) ``radec`` can be a numpy array of shape (2,) or (N, 2),
+        or an equivalent python object. The number of neighbours ``k`` must be a
+        positive integer and the optional ``max_ang`` parameter puts an upper
+        bound on the angular separation (in radian) to the neighbours.
+
+        Returns an array with fields ``index``, holding the index to the neighbour
+        in the array from which the tree was constructed, and ``angle``, the
+        angular separation in radian. The result is sorted by separation,
+        missing neighbours (e.g. if ``angle > max_ang``) are indicated by an
+        index of -1 and infinite separation.
+        """
+        xyz = coord.angular_to_euclidean(radec)
+        if max_ang > 0:
+            max_dist = coord.angle_to_chorddist(max_ang)
+        else:
+            max_dist = -1.0
+        raw = super().nearest_neighbours(xyz, k, max_dist=max_dist)
+        good = raw["index"] >= 0
+
+        result = np.empty(raw.shape, dtype=[("index", "i8"), ("angle", "f8")])
+        result["index"] = raw["index"]
+        result["angle"][~good] = np.inf
+        result["angle"][good] = coord.chorddist_to_angle(raw["distance"][good])
+        return result
 
     def brute_radius(
         self,

--- a/balltree/balltree.c
+++ b/balltree/balltree.c
@@ -504,7 +504,7 @@ static PyObject *statvec_get_numpy_array(StatsVector *vec) {
     // create an uninitialised array and copy the data into it
     PyObject *array = PyArray_Empty(ndim, shape, arr_descr, 0);
     if (array == NULL) {
-        Py_XDECREF(arr_descr);
+        Py_DECREF(arr_descr);
         return NULL;
     }
     void *ptr = PyArray_DATA(array);
@@ -537,7 +537,7 @@ static PyObject *queueitems_get_numpy_array(QueueItem *items, npy_intp size, npy
     // create an uninitialised array and copy the data into it
     PyObject *array = PyArray_Empty(ndim, shape, arr_descr, 0);
     if (array == NULL) {
-        Py_XDECREF(arr_descr);
+        Py_DECREF(arr_descr);
         return NULL;
     }
     void *ptr = PyArray_DATA(array);
@@ -655,8 +655,8 @@ PyDoc_STRVAR(
     "--\n\n"
     "Build a new BallTree instance from randomly generated points.\n\n"
     "The (x, y, z) coordinates are generated uniformly in the interval\n"
-    "[`low`, `high`), `size` controlls the number of points generated. The\n"
-    "optional `leafsize` determines when the tree query algorithms switch from\n"
+    "[``low``, ``high``), ``size`` controlls the number of points generated. The\n"
+    "optional ``leafsize`` determines when the tree query algorithms switch from\n"
     "traversal to brute force."
 );
 
@@ -900,8 +900,9 @@ PyDoc_STRVAR(
     "get_node_data(self) -> NDArray\n"
     "--\n\n"
     "Collect the meta data of all tree nodes in a numpy array.\n\n"
-    "The array fields record `depth` (starting from the root node),\n"
-    "`num_points`, `sum_weight`, `x`, `y`, `z` (node center) and node `radius`."
+    "The array fields record ``depth`` (starting from the root node),\n"
+    "``num_points``, ``sum_weight``, ``x``, ``y``, ``z`` (node center) and node\n"
+    "``radius``."
 );
 
 static PyObject *PyBallTree_get_node_data(PyBallTree *self) {
@@ -918,10 +919,18 @@ static PyObject *PyBallTree_get_node_data(PyBallTree *self) {
 PyDoc_STRVAR(
     // .. py:method::
     nearest_neighbours_doc,
-    "nearest_neighbours(self, xyz: ArrayLike, k: int, max_dist: float) -> NDArray\n"
+    "nearest_neighbours(self, xyz: ArrayLike, k: int, max_dist: float = -1.0) -> NDArray\n"
     "--\n\n"
-    "Find a number of nearest neighbours.\n\n"
-    "TODO"
+    "Query a fixed number of nearest neighbours.\n\n"
+    "The query point(s) ``xyz`` can be a numpy array of shape (3,) or (N, 3),\n"
+    "or an equivalent python object. The number of neighbours ``k`` must be a\n"
+    "positive integer and the optional ``max_dist`` parameter puts an upper\n"
+    "bound on the separation to the neighbours.\n\n"
+    "Returns an array with fields ``index``, holding the index to the neighbour\n"
+    "in the array from which the tree was constructed, and ``distance``, the\n"
+    "separation. The result is sorted by separation, missing neighbours (e.g. if\n"
+    "``distance > max_dist``) are indicated by an index of -1 and infinite\n"
+    "separation.\n"
 );
 
 static PyObject *PyBallTree_nearest_neighbours(
@@ -976,7 +985,7 @@ static PyObject *PyBallTree_nearest_neighbours(
         }
         // copy result into output buffer
         memcpy(&result[idx], queue->items, n_bytes_queue);
-        free(queue);
+        knque_free(queue);
         idx += num_neighbours;
     }
 

--- a/balltree/balltree.c
+++ b/balltree/balltree.c
@@ -947,6 +947,11 @@ static PyObject *PyBallTree_nearest_neighbours(
     Point point = {0.0, 0.0, 0.0, 0.0, 0};
     PyObject *pyresult = NULL;
     while (iter_get_next_xyz(data->xyz_iter, &point.x, &point.y, &point.z)) {
+        if (idx > 0) {
+            PyErr_SetString(PyExc_NotImplementedError, "multiple neighbour query not yet available");
+            return NULL;
+        }
+
         QueueItem *result = balltree_nearest_neighbours(
             self->balltree,
             &point,
@@ -954,17 +959,15 @@ static PyObject *PyBallTree_nearest_neighbours(
             max_dist
         );
         if (result == NULL) {
-            inputiterdata_free(data);
-            return NULL;
+            goto error;
         }
         pyresult = queueitems_get_numpy_array(result, num_neighbours);
         free(result);
-
-        break;
         ++idx;
     }
-    inputiterdata_free(data);
 
+error:
+    inputiterdata_free(data);
     return pyresult;
 }
 

--- a/balltree/balltree.c
+++ b/balltree/balltree.c
@@ -931,12 +931,16 @@ static PyObject *PyBallTree_nearest_neighbours(
 ) {
     static char *kwlist[] = {"xyz", "k", "max_dist", NULL};
     PyObject *xyz_obj;
-    int num_neighbours;
+    long num_neighbours;  // screw Windows
     double max_dist = -1.0;
     if (!PyArg_ParseTupleAndKeywords(
-            args, kwargs, "Oi|d", kwlist,
+            args, kwargs, "Ol|d", kwlist,
             &xyz_obj, &num_neighbours, &max_dist)
     ) {
+        return NULL;
+    }
+    if (num_neighbours < 1) {
+        PyErr_SetString(PyExc_ValueError, "number of neighbours must be positive");
         return NULL;
     }
 
@@ -949,6 +953,7 @@ static PyObject *PyBallTree_nearest_neighbours(
     size_t n_bytes_queue = num_neighbours * sizeof(QueueItem);
     QueueItem *result = malloc(data->size * n_bytes_queue);
     if (result == NULL) {
+        PyErr_SetString(PyExc_MemoryError, "failed to allocate output array");
         inputiterdata_free(data);
         return NULL;
     }
@@ -966,6 +971,7 @@ static PyObject *PyBallTree_nearest_neighbours(
             max_dist
         );
         if (queue == NULL) {
+            printf("oops\n");
             goto error;
         }
         // copy result into output buffer

--- a/include/ballnode.h
+++ b/include/ballnode.h
@@ -58,7 +58,7 @@ int bnode_is_leaf(const BallNode *);
 PointSlice bnode_get_ptslc(const BallNode *);
 
 // from ballnode_query.c
-void bnode_find_neighbours(const BallNode *, const Point *, KnnQueue *);
+void bnode_nearest_neighbours(const BallNode *, const Point *, KnnQueue *);
 double bnode_count_radius(const BallNode *, const Point *, double);
 void bnode_count_range(const BallNode *, const Point *, DistHistogram *);
 double bnode_dualcount_radius(const BallNode *, const BallNode *, double);

--- a/include/ballnode.h
+++ b/include/ballnode.h
@@ -5,6 +5,7 @@
 
 #include "point.h"
 #include "histogram.h"
+#include "queue.h"
 
 #define BALLNODE_IS_LEAF(node) (node)->is_leaf
 
@@ -57,6 +58,7 @@ int bnode_is_leaf(const BallNode *);
 PointSlice bnode_get_ptslc(const BallNode *);
 
 // from ballnode_query.c
+void bnode_find_neighbours(const BallNode *, const Point *, KnnQueue *);
 double bnode_count_radius(const BallNode *, const Point *, double);
 void bnode_count_range(const BallNode *, const Point *, DistHistogram *);
 double bnode_dualcount_radius(const BallNode *, const BallNode *, double);

--- a/include/balltree.h
+++ b/include/balltree.h
@@ -22,7 +22,7 @@ BallTree *balltree_build_leafsize(const PointBuffer *, int);
 BallTree* balltree_build_nocopy(PointBuffer *, int);
 void balltree_free(BallTree *);
 
-QueueItem *balltree_find_neighbours(const BallTree *, const Point *, int64_t, double);
+QueueItem *balltree_nearest_neighbours(const BallTree *, const Point *, int64_t, double);
 double balltree_brute_radius(const BallTree *, const Point *, double);
 void balltree_brute_range(const BallTree *, const Point *, DistHistogram *);
 double balltree_count_radius(const BallTree *, const Point *, double);

--- a/include/balltree.h
+++ b/include/balltree.h
@@ -22,6 +22,7 @@ BallTree *balltree_build_leafsize(const PointBuffer *, int);
 BallTree* balltree_build_nocopy(PointBuffer *, int);
 void balltree_free(BallTree *);
 
+QueueItem *balltree_find_neighbours(const BallTree *, const Point *, int64_t, double);
 double balltree_brute_radius(const BallTree *, const Point *, double);
 void balltree_brute_range(const BallTree *, const Point *, DistHistogram *);
 double balltree_count_radius(const BallTree *, const Point *, double);

--- a/include/balltree.h
+++ b/include/balltree.h
@@ -22,7 +22,7 @@ BallTree *balltree_build_leafsize(const PointBuffer *, int);
 BallTree* balltree_build_nocopy(PointBuffer *, int);
 void balltree_free(BallTree *);
 
-QueueItem *balltree_nearest_neighbours(const BallTree *, const Point *, int64_t, double);
+KnnQueue *balltree_nearest_neighbours(const BallTree *, const Point *, int64_t, double);
 double balltree_brute_radius(const BallTree *, const Point *, double);
 void balltree_brute_range(const BallTree *, const Point *, DistHistogram *);
 double balltree_count_radius(const BallTree *, const Point *, double);

--- a/include/point.h
+++ b/include/point.h
@@ -10,6 +10,7 @@ typedef struct {
     double y;
     double z;
     double weight;
+    int64_t index;
 } Point;
 
 typedef struct {
@@ -35,8 +36,6 @@ double point_dist_sq(const Point *, const Point *);
 
 // from pointbuffers.c
 PointBuffer *ptbuf_new(int64_t);
-PointBuffer *ptbuf_from_buffers(int64_t, double *, double *, double *);
-PointBuffer *ptbuf_from_buffers_weighted(int64_t, double *, double *, double *, double *);
 void ptbuf_free(PointBuffer *);
 int ptbuf_resize(PointBuffer *, int64_t);
 PointBuffer *ptbuf_copy(const PointBuffer *);

--- a/include/queue.h
+++ b/include/queue.h
@@ -5,24 +5,21 @@
 
 #include "point.h"
 
-# define QUEUEITEM_T Point
-# define QUEUEITEM_DEFAULT (Point){0.0, 0.0, 0.0, 0.0}
-
 typedef struct {
-    QUEUEITEM_T value;
-    double dist_sq;
+    int64_t index;
+    double distance;
 } QueueItem;
 
 typedef struct {
     int64_t capacity;
     int64_t size;
     QueueItem *items;
-    double dist_sq_max;
+    double distance_max;
 } KnnQueue;
 
 KnnQueue *knque_new(int64_t);
 void knque_free(KnnQueue *);
 void knque_clear(KnnQueue *queue);
-int knque_insert(KnnQueue *, const QUEUEITEM_T *, double);
+int knque_insert(KnnQueue *, int64_t, double);
 
 #endif /* QUEUE_H */

--- a/include/queue.h
+++ b/include/queue.h
@@ -22,4 +22,10 @@ void knque_free(KnnQueue *);
 void knque_clear(KnnQueue *queue);
 int knque_insert(KnnQueue *, int64_t, double);
 
+double inline knque_get_max_dist(KnnQueue *queue) {
+    double limit = queue->distance_max;
+    double dynamic = queue->items[queue->capacity - 1].distance;
+    return (limit < dynamic) ? limit : dynamic;
+}
+
 #endif /* QUEUE_H */

--- a/include/queue.h
+++ b/include/queue.h
@@ -1,0 +1,28 @@
+#ifndef QUEUE_H
+#define QUEUE_H
+
+#include <stdint.h>
+
+#include "point.h"
+
+# define QUEUEITEM_T Point
+# define QUEUEITEM_DEFAULT (Point){0.0, 0.0, 0.0, 0.0}
+
+typedef struct {
+    QUEUEITEM_T value;
+    double dist_sq;
+} QueueItem;
+
+typedef struct {
+    int64_t capacity;
+    int64_t size;
+    QueueItem *items;
+    double dist_sq_max;
+} KnnQueue;
+
+KnnQueue *knque_new(int64_t);
+void knque_free(KnnQueue *);
+void knque_clear(KnnQueue *queue);
+int knque_insert(KnnQueue *, const QUEUEITEM_T *, double);
+
+#endif /* QUEUE_H */

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
     "black",
     "flake8",
     "pre-commit",
+    "ipykernel",
 ]
 
 [tool.setuptools.dynamic]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 numpy>=1.21
+# [test]
 pytest

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,10 +1,14 @@
 numpy>=1.21
+# [test]
 pytest
-black
-isort
-flake8
-pre-commit
+# [docs]
 sphinx
 sphinx-design
 sphinx-copybutton
 pydata-sphinx-theme
+# [dev]
+black
+isort
+flake8
+pre-commit
+ipykernel

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ balltree = Extension(
         "src/point.c",
         "src/pointbuffers.c",
         "src/histogram.c",
+        "src/queue.c",
         "src/ballnode.c",
         "src/ballnode_stats.c",
         "src/ballnode_query.c",

--- a/src/ballnode_query.c
+++ b/src/ballnode_query.c
@@ -39,14 +39,12 @@ static inline void ptslc_dualsumw_in_hist_sq(
     }
 }
 
-void bnode_find_neighbours(const BallNode *node, const Point *point, KnnQueue *queue) {
+void bnode_nearest_neighbours(const BallNode *node, const Point *point, KnnQueue *queue) {
     int queue_is_full = queue->capacity == queue->size;
     double distance = sqrt(EUCLIDEAN_DIST_SQ(&node->ball, point));
-    double node_radius = node->ball.radius;
 
     // case: minimum distance to node exceeds most distant neighbour so far
-    double dist_sq_min = (distance - node_radius) * (distance - node_radius);
-    if (queue_is_full && dist_sq_min >= queue->dist_sq_max) {
+    if (queue_is_full && distance - node->ball.radius >= queue->distance_max) {
         return;
     }
 
@@ -58,17 +56,17 @@ void bnode_find_neighbours(const BallNode *node, const Point *point, KnnQueue *q
         double dist_sq_right = EUCLIDEAN_DIST_SQ(&right->ball, point);
         // priortising closer node may allow pruning more distance node
         if (dist_sq_left < dist_sq_right) {
-            bnode_find_neighbours(left, point, queue);
+            bnode_nearest_neighbours(left, point, queue);
         } else {
-            bnode_find_neighbours(right, point, queue);
+            bnode_nearest_neighbours(right, point, queue);
         }
         return;
     }
 
     // case: node is a leaf and any point may be closer than those in queue
     for (const Point *point = node->data.start; point < node->data.end; ++point) {
-        double dist_sq = EUCLIDEAN_DIST_SQ(point, point);
-        knque_insert(queue, point, dist_sq);
+        double distance = sqrt(EUCLIDEAN_DIST_SQ(point, point));
+        knque_insert(queue, point->index, distance);
     }
 }
 

--- a/src/ballnode_query.c
+++ b/src/ballnode_query.c
@@ -39,9 +39,9 @@ static inline void ptslc_dualsumw_in_hist_sq(
     }
 }
 
-void bnode_nearest_neighbours(const BallNode *node, const Point *point, KnnQueue *queue) {
+void bnode_nearest_neighbours(const BallNode *node, const Point *ref_point, KnnQueue *queue) {
     int queue_is_full = queue->capacity == queue->size;
-    double distance = sqrt(EUCLIDEAN_DIST_SQ(&node->ball, point));
+    double distance = sqrt(EUCLIDEAN_DIST_SQ(&node->ball, ref_point));
 
     // case: minimum distance to node exceeds most distant neighbour so far
     if (queue_is_full && distance - node->ball.radius >= queue->distance_max) {
@@ -52,20 +52,22 @@ void bnode_nearest_neighbours(const BallNode *node, const Point *point, KnnQueue
     if (BALLNODE_IS_LEAF(node) == false) {
         BallNode *left = node->childs.left;
         BallNode *right = node->childs.right;
-        double dist_sq_left = EUCLIDEAN_DIST_SQ(&left->ball, point);
-        double dist_sq_right = EUCLIDEAN_DIST_SQ(&right->ball, point);
+        double dist_sq_left = EUCLIDEAN_DIST_SQ(&left->ball, ref_point);
+        double dist_sq_right = EUCLIDEAN_DIST_SQ(&right->ball, ref_point);
         // priortising closer node may allow pruning more distance node
         if (dist_sq_left < dist_sq_right) {
-            bnode_nearest_neighbours(left, point, queue);
+            bnode_nearest_neighbours(left, ref_point, queue);
+            bnode_nearest_neighbours(right, ref_point, queue);
         } else {
-            bnode_nearest_neighbours(right, point, queue);
+            bnode_nearest_neighbours(right, ref_point, queue);
+            bnode_nearest_neighbours(left, ref_point, queue);
         }
         return;
     }
 
     // case: node is a leaf and any point may be closer than those in queue
     for (const Point *point = node->data.start; point < node->data.end; ++point) {
-        double distance = sqrt(EUCLIDEAN_DIST_SQ(point, point));
+        double distance = sqrt(EUCLIDEAN_DIST_SQ(ref_point, point));
         knque_insert(queue, point->index, distance);
     }
 }

--- a/src/ballnode_query.c
+++ b/src/ballnode_query.c
@@ -44,7 +44,7 @@ void bnode_nearest_neighbours(const BallNode *node, const Point *ref_point, KnnQ
     double distance = sqrt(EUCLIDEAN_DIST_SQ(&node->ball, ref_point));
 
     // case: minimum distance to node exceeds most distant neighbour so far
-    if (queue_is_full && distance - node->ball.radius >= queue->distance_max) {
+    if (queue_is_full && distance - node->ball.radius >= knque_get_max_dist(queue)) {
         return;
     }
 

--- a/src/balltree.c
+++ b/src/balltree.c
@@ -82,7 +82,6 @@ QueueItem *balltree_nearest_neighbours(
         queue->distance_max = max_dist;
     }
     bnode_nearest_neighbours(tree->root, point, queue);
-    printf("WARNING: The first element is dropped on insertion!\n");
 
     // copy result to new buffer
     size_t n_bytes = num_neighbours * sizeof(QueueItem);

--- a/src/balltree.c
+++ b/src/balltree.c
@@ -68,7 +68,7 @@ void balltree_free(BallTree *tree) {
     free(tree);
 }
 
-QueueItem *balltree_nearest_neighbours(
+KnnQueue *balltree_nearest_neighbours(
     const BallTree *tree,
     const Point *point,
     int64_t num_neighbours,
@@ -82,16 +82,7 @@ QueueItem *balltree_nearest_neighbours(
         queue->distance_max = max_dist;
     }
     bnode_nearest_neighbours(tree->root, point, queue);
-
-    // copy result to new buffer
-    size_t n_bytes = num_neighbours * sizeof(QueueItem);
-    QueueItem *result = malloc(n_bytes);
-    if (result == NULL) {
-        EMIT_ERR_MSG(MemoryError, "result buffer allocation failed");
-    }
-    memcpy(result, queue->items, n_bytes);
-    knque_free(queue);
-    return result;
+    return queue;
 }
 
 double balltree_brute_radius(

--- a/src/balltree.c
+++ b/src/balltree.c
@@ -68,7 +68,7 @@ void balltree_free(BallTree *tree) {
     free(tree);
 }
 
-QueueItem *balltree_find_neighbours(
+QueueItem *balltree_nearest_neighbours(
     const BallTree *tree,
     const Point *point,
     int64_t num_neighbours,
@@ -78,8 +78,8 @@ QueueItem *balltree_find_neighbours(
     if (queue == NULL) {
         return NULL;
     }
-    queue->dist_sq_max = max_dist * max_dist;
-    bnode_find_neighbours(tree->root, point, queue);
+    queue->distance_max = max_dist;
+    bnode_nearest_neighbours(tree->root, point, queue);
 
     // copy result to new buffer
     size_t n_bytes = num_neighbours * sizeof(QueueItem);

--- a/src/balltree.c
+++ b/src/balltree.c
@@ -78,8 +78,11 @@ QueueItem *balltree_nearest_neighbours(
     if (queue == NULL) {
         return NULL;
     }
-    queue->distance_max = max_dist;
+    if (max_dist >= 0.0) {
+        queue->distance_max = max_dist;
+    }
     bnode_nearest_neighbours(tree->root, point, queue);
+    printf("WARNING: The first element is dropped on insertion!\n");
 
     // copy result to new buffer
     size_t n_bytes = num_neighbours * sizeof(QueueItem);

--- a/src/main.c
+++ b/src/main.c
@@ -105,6 +105,16 @@ int main(int argc, char** argv) {
     count = balltree_dualcount_radius(tree2, tree2, query_radius);
     printf("self found %11.0lf pairs\n", count);
 
+    int N = 100;
+    time = clock();
+    KnnQueue *queue = balltree_nearest_neighbours(tree2, tree2->data->points, N, -1.0);
+    if (queue == NULL) {
+        return 1;
+    }
+    elapsed = (double)(clock() - time) / CLOCKS_PER_SEC * 1000.0;
+    knque_free(queue);
+    printf("found %d nearest neighbours in %7.3lf ms\n", N, elapsed);
+
     balltree_free(tree2);
     return 0;
 }

--- a/src/point.c
+++ b/src/point.c
@@ -12,6 +12,7 @@ Point point_create_weighted(double x, double y, double z, double weight) {
         .y = y,
         .z = z,
         .weight = weight,
+        .index = 0,
     };
 }
 

--- a/src/pointbuffers.c
+++ b/src/pointbuffers.c
@@ -27,44 +27,13 @@ PointBuffer *ptbuf_new(int64_t size) {
         ptbuf_free(buffer);
         return NULL;
     }
+    // initialise range index
+    for (int64_t i = 0; i < size; ++i) {
+        points[i].index = i;
+    }
 
     buffer->size = size;
     buffer->points = points;
-    return buffer;
-}
-
-PointBuffer *ptbuf_from_buffers(
-    int64_t size,
-    double *x_vals,
-    double *y_vals,
-    double *z_vals
-) {
-    PointBuffer *buffer = ptbuf_new(size);
-    if (buffer == NULL) {
-        return NULL;
-    }
-    Point *points = buffer->points;
-    for (int64_t i = 0; i < size; ++i) {
-        points[i] = point_create(x_vals[i], y_vals[i], z_vals[i]);
-    }
-    return buffer;
-}
-
-PointBuffer *ptbuf_from_buffers_weighted(
-    int64_t size,
-    double *x_vals,
-    double *y_vals,
-    double *z_vals,
-    double *weights
-) {
-    PointBuffer *buffer = ptbuf_from_buffers(size, x_vals, y_vals, z_vals);
-    if (buffer == NULL) {
-        return NULL;
-    }
-    Point *points = buffer->points;
-    for (int64_t i = 0; i < size; ++i) {
-        points[i].weight = weights[i];
-    }
     return buffer;
 }
 
@@ -86,6 +55,12 @@ int ptbuf_resize(PointBuffer *buffer, int64_t size) {
     if (points == NULL) {
         EMIT_ERR_MSG(MemoryError, "PointBuffer resizing failed");
         return BTR_FAILED;
+    }
+    // update range index
+    if (size > buffer->size) {
+        for (int64_t i = buffer->size; i < size; ++i) {
+            points[i].index = i;
+        }
     }
 
     buffer->size = size;
@@ -116,10 +91,11 @@ PointBuffer *ptbuf_gen_random(double low, double high, int64_t num_points) {
     }
 
     for (int64_t i = 0; i < num_points; ++i) {
-        double x = rand_uniform(low, high);
-        double y = rand_uniform(low, high);
-        double z = rand_uniform(low, high);
-        buffer->points[i] = point_create(x, y, z);
+        Point *point = buffer->points + i;
+        point->x = rand_uniform(low, high);
+        point->y = rand_uniform(low, high);
+        point->z = rand_uniform(low, high);
+        point->weight = 1.0;
     }
     return buffer;
 }

--- a/src/queue.c
+++ b/src/queue.c
@@ -41,7 +41,7 @@ void knque_free(KnnQueue *queue) {
 void knque_clear(KnnQueue *queue) {
     queue->size = 0;
     queue->distance_max = INFINITY;
-    for (long i = 0; i < queue->capacity; ++i) {
+    for (int64_t i = 0; i < queue->capacity; ++i) {
         queue->items[i] = (QueueItem){
             .index = -1,
             .distance = INFINITY,
@@ -58,8 +58,8 @@ int knque_insert(KnnQueue *queue, int64_t item_index, double distance) {
     // the actual location is reached when the element at the preceeding index
     // is smaller than the item to be inserted
     QueueItem *items = queue->items;
-    long idx_last = (queue->size > 0) ? (queue->size - 1) : 0;
-    long idx_insert = idx_last;
+    int64_t idx_last = (queue->size > 0) ? (queue->size - 1) : 0;
+    int64_t idx_insert = idx_last;
     for (; idx_insert >= 0; --idx_insert) {
         if (items[idx_insert - 1].distance <= distance) {
             break;
@@ -74,7 +74,7 @@ int knque_insert(KnnQueue *queue, int64_t item_index, double distance) {
         items[queue->size] = items[idx_last];
         ++(queue->size);
     }
-    for (long idx_dest = idx_last; idx_dest > idx_insert; --idx_dest) {
+    for (int64_t idx_dest = idx_last; idx_dest > idx_insert; --idx_dest) {
         items[idx_dest] = items[idx_dest - 1];
     }
     items[idx_insert].index = item_index;

--- a/src/queue.c
+++ b/src/queue.c
@@ -50,13 +50,12 @@ void knque_clear(KnnQueue *queue) {
 }
 
 int knque_insert(KnnQueue *queue, int64_t item_index, double distance) {
-    if (distance >= queue->distance_max) {
+    QueueItem *items = queue->items;
+    if (distance >= knque_get_max_dist(queue)) {
         return 1;  // item not in queue
     }
 
-    QueueItem *items = queue->items;
-
-    // find insertion index, note that (distance < queue->distance_max)
+    // find insertion index, note that (distance < distance_last_element)
     int64_t idx_insert = queue->size;
     while (idx_insert > 0 && distance < items[idx_insert - 1].distance) {
         --idx_insert;
@@ -77,6 +76,5 @@ int knque_insert(KnnQueue *queue, int64_t item_index, double distance) {
     if (!queue_is_full) {
         ++(queue->size);
     }
-    queue->distance_max = items[queue->capacity - 1].distance;
     return 0;
 }

--- a/src/queue.c
+++ b/src/queue.c
@@ -40,17 +40,17 @@ void knque_free(KnnQueue *queue) {
 
 void knque_clear(KnnQueue *queue) {
     queue->size = 0;
-    queue->dist_sq_max = INFINITY;
+    queue->distance_max = INFINITY;
     for (long i = 0; i < queue->capacity; ++i) {
         queue->items[i] = (QueueItem){
-            .value = QUEUEITEM_DEFAULT,
-            .dist_sq = INFINITY,
+            .index = -1,
+            .distance = INFINITY,
         };
     }
 }
 
-int knque_insert(KnnQueue *queue, const QUEUEITEM_T *value, double dist_sq) {
-    if (dist_sq >= queue->dist_sq_max) {
+int knque_insert(KnnQueue *queue, int64_t item_index, double distance) {
+    if (distance >= queue->distance_max) {
         return 1;
     }
     // insertion index must now be at least at end of queue
@@ -61,8 +61,7 @@ int knque_insert(KnnQueue *queue, const QUEUEITEM_T *value, double dist_sq) {
     long idx_last = (queue->size > 0) ? (queue->size - 1) : 0;
     long idx_insert = idx_last;
     for (; idx_insert >= 0; --idx_insert) {
-        double dist_sq_next = items[idx_insert - 1].dist_sq;
-        if (dist_sq_next <= dist_sq) {
+        if (items[idx_insert - 1].distance <= distance) {
             break;
         }
     }
@@ -78,11 +77,11 @@ int knque_insert(KnnQueue *queue, const QUEUEITEM_T *value, double dist_sq) {
     for (long idx_dest = idx_last; idx_dest > idx_insert; --idx_dest) {
         items[idx_dest] = items[idx_dest - 1];
     }
-    items[idx_insert].value = *value;
-    items[idx_insert].dist_sq = dist_sq;
+    items[idx_insert].index = item_index;
+    items[idx_insert].distance = distance;
 
     if (is_full) {  // last element in queue has changed
-        queue->dist_sq_max = items[queue->size - 1].dist_sq;
+        queue->distance_max = items[queue->size - 1].distance;
     }
 
     return 0;

--- a/src/queue.c
+++ b/src/queue.c
@@ -1,0 +1,96 @@
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "queue.h"
+#include "balltree_macros.h"
+
+static inline int knque_is_full(const KnnQueue *queue);
+
+
+KnnQueue *knque_new(int64_t capacity) {
+    if (capacity < 1) {
+        EMIT_ERR_MSG(ValueError, "KnnQueue capacity must be positive");
+        return NULL;
+    }
+
+    KnnQueue *queue = malloc(sizeof(KnnQueue));
+    if (queue == NULL) {
+        EMIT_ERR_MSG(MemoryError, "KnnQueue allocation failed");
+        return NULL;
+    }
+
+    QueueItem *items = calloc(capacity, sizeof(QueueItem));
+    if (items == NULL) {
+        EMIT_ERR_MSG(MemoryError, "KnnQueue.items allocation failed");
+        knque_free(queue);
+        return NULL;
+    }
+
+    queue->items = items;
+    queue->capacity = capacity;
+    knque_clear(queue);
+    return queue;
+}
+
+void knque_free(KnnQueue *queue) {
+    if (queue->items != NULL) {
+        free(queue->items);
+    }
+    free(queue);
+}
+
+void knque_clear(KnnQueue *queue) {
+    queue->size = 0;
+    queue->dist_sq_max = INFINITY;
+    for (long i = 0; i < queue->capacity; ++i) {
+        queue->items[i] = (QueueItem){
+            .value = QUEUEITEM_DEFAULT,
+            .dist_sq = INFINITY,
+        };
+    }
+}
+
+static inline int knque_is_full(const KnnQueue *queue) {
+    return queue->capacity == queue->size;
+}
+
+int knque_insert(KnnQueue *queue, const QUEUEITEM_T *value, double dist_sq) {
+    if (dist_sq >= queue->dist_sq_max) {
+        return 1;
+    }
+    // insertion index must now be at least at end of queue
+
+    // the actual location is reached when the element at the preceeding index
+    // is smaller than the item to be inserted
+    QueueItem *items = queue->items;
+    long idx_last = (queue->size > 0) ? (queue->size - 1) : 0;
+    long idx_insert = idx_last;
+    for (; idx_insert >= 0; --idx_insert) {
+        double dist_sq_next = items[idx_insert - 1].dist_sq;
+        if (dist_sq_next <= dist_sq) {
+            break;
+        }
+    }
+
+    // shift up all items by one to make room for new item, drop last item if
+    // the queue is full
+    int is_full = knque_is_full(queue);
+    if (!is_full) {
+        // increase size and shift up last element
+        items[queue->size] = items[idx_last];
+        ++(queue->size);
+    }
+    for (long idx_dest = idx_last; idx_dest > idx_insert; --idx_dest) {
+        items[idx_dest] = items[idx_dest - 1];
+    }
+    items[idx_insert].value = *value;
+    items[idx_insert].dist_sq = dist_sq;
+
+    if (is_full) {  // last element in queue has changed
+        queue->dist_sq_max = items[queue->size - 1].dist_sq;
+    }
+
+    return 0;
+}

--- a/src/queue.c
+++ b/src/queue.c
@@ -50,6 +50,10 @@ void knque_clear(KnnQueue *queue) {
 }
 
 int knque_insert(KnnQueue *queue, int64_t item_index, double distance) {
+    if (distance >= queue->distance_max) {
+        return 1;  // item not in queue
+    }
+
     QueueItem *items = queue->items;
 
     // find insertion index, note that (distance < queue->distance_max)
@@ -57,9 +61,7 @@ int knque_insert(KnnQueue *queue, int64_t item_index, double distance) {
     while (idx_insert > 0 && distance < items[idx_insert - 1].distance) {
         --idx_insert;
     }
-    if (idx_insert == queue->capacity) {
-        return 1;  // item not in queue
-    }
+    // very first if statement guarantees (idx_insert < queue->capacity)
 
     // make room and insert item, drop last item if at capacity
     int queue_is_full = queue->size == queue->capacity;
@@ -74,7 +76,8 @@ int knque_insert(KnnQueue *queue, int64_t item_index, double distance) {
     // update state of queue
     if (!queue_is_full) {
         ++(queue->size);
+    } else {
+        queue->distance_max = items[queue->size - 1].distance;
     }
-    queue->distance_max = items[queue->size - 1].distance;
     return 0;
 }

--- a/src/queue.c
+++ b/src/queue.c
@@ -6,9 +6,6 @@
 #include "queue.h"
 #include "balltree_macros.h"
 
-static inline int knque_is_full(const KnnQueue *queue);
-
-
 KnnQueue *knque_new(int64_t capacity) {
     if (capacity < 1) {
         EMIT_ERR_MSG(ValueError, "KnnQueue capacity must be positive");
@@ -52,10 +49,6 @@ void knque_clear(KnnQueue *queue) {
     }
 }
 
-static inline int knque_is_full(const KnnQueue *queue) {
-    return queue->capacity == queue->size;
-}
-
 int knque_insert(KnnQueue *queue, const QUEUEITEM_T *value, double dist_sq) {
     if (dist_sq >= queue->dist_sq_max) {
         return 1;
@@ -76,7 +69,7 @@ int knque_insert(KnnQueue *queue, const QUEUEITEM_T *value, double dist_sq) {
 
     // shift up all items by one to make room for new item, drop last item if
     // the queue is full
-    int is_full = knque_is_full(queue);
+    int is_full = queue->capacity == queue->size;
     if (!is_full) {
         // increase size and shift up last element
         items[queue->size] = items[idx_last];

--- a/src/queue.c
+++ b/src/queue.c
@@ -18,7 +18,7 @@ KnnQueue *knque_new(int64_t capacity) {
         return NULL;
     }
 
-    QueueItem *items = calloc(capacity, sizeof(QueueItem));
+    QueueItem *items = malloc(capacity * sizeof(QueueItem));
     if (items == NULL) {
         EMIT_ERR_MSG(MemoryError, "KnnQueue.items allocation failed");
         knque_free(queue);
@@ -76,8 +76,7 @@ int knque_insert(KnnQueue *queue, int64_t item_index, double distance) {
     // update state of queue
     if (!queue_is_full) {
         ++(queue->size);
-    } else {
-        queue->distance_max = items[queue->size - 1].distance;
     }
+    queue->distance_max = items[queue->capacity - 1].distance;
     return 0;
 }

--- a/tests/test_angulartree.py
+++ b/tests/test_angulartree.py
@@ -55,13 +55,14 @@ def test_count_range():
     return np.diff([1, 5, 6], prepend=0.0)  # prepend is for count with itself
 
 
-def data_to_view(data, weight=True):
-    dtype = [("ra", "f8"), ("dec", "f8"), ("weight", "f8")]
+def data_to_view(data, weight=None, index=None):
+    dtype = [("ra", "f8"), ("dec", "f8"), ("weight", "f8"), ("index", "i8")]
     data = np.atleast_2d(data)
     array = np.empty(len(data), dtype=dtype)
     array["ra"] = data[:, 0]
     array["dec"] = data[:, 1]
     array["weight"] = weight if weight is not None else 1.0
+    array["index"] = index if index is not None else np.arange(len(data))
     return array
 
 

--- a/tests/test_angulartree.py
+++ b/tests/test_angulartree.py
@@ -117,6 +117,9 @@ class TestAngularTree:
     def test_count_nodes(self, mock_data):
         assert AngularTree(mock_data, leafsize=4).count_nodes() == 3
 
+    # NOTE: nearest_neighbour doesn't need testing since it does not depende on
+    #       the choice of coordinates or the unit of the separation
+
     def test_brute_radius(self, mock_tree, test_angles, test_count):
         point = (0.0, 0.0)
         for angle, count in zip(test_angles, test_count):

--- a/tests/test_angulartree.py
+++ b/tests/test_angulartree.py
@@ -117,8 +117,16 @@ class TestAngularTree:
     def test_count_nodes(self, mock_data):
         assert AngularTree(mock_data, leafsize=4).count_nodes() == 3
 
-    # NOTE: nearest_neighbour doesn't need testing since it does not depende on
-    #       the choice of coordinates or the unit of the separation
+    def test_nearest_neighbours(self, mock_tree):
+        result = mock_tree.nearest_neighbours((0.0, 0.0), 5)[0]
+        npt.assert_almost_equal(result["angle"][0], 0)
+        npt.assert_almost_equal(result["angle"][1:], PI_2)
+
+    def test_nearest_neighbours_max_dist(self, mock_tree):
+        max_dist = PI_2 - 1e-9
+        result = mock_tree.nearest_neighbours((0.0, 0.0), 5, max_dist)[0]
+        npt.assert_almost_equal(result["angle"][0], 0)
+        npt.assert_almost_equal(result["angle"][1:], np.inf)
 
     def test_brute_radius(self, mock_tree, test_angles, test_count):
         point = (0.0, 0.0)

--- a/tests/test_balltree.py
+++ b/tests/test_balltree.py
@@ -221,12 +221,12 @@ class TestBallTree:
     @pytest.mark.parametrize("radius", radius_testvalues)
     def test_brute_radius_multi(self, radius, rand_data_weight):
         data, weight = rand_data_weight
-        tree = BallTree(data, weight)
+        result = BallTree(data, weight).brute_radius(data, radius, weight)
 
-        count = 0.0
+        expect = 0.0
         for p, w in zip(data, weight):
-            count += brute_force((data, weight), (p, w), radius)
-        npt.assert_almost_equal(tree.brute_radius(data, radius, weight), count)
+            expect += brute_force((data, weight), (p, w), radius)
+        npt.assert_almost_equal(result, expect)
 
     def test_count_radius_no_radius(self, rand_data_weight):
         data, _ = rand_data_weight
@@ -238,96 +238,97 @@ class TestBallTree:
     def test_count_radius_single(self, radius, rand_data_weight):
         data, _ = rand_data_weight
         weight = np.ones(len(data))
-        tree = BallTree(data)
-
         p = data[0]
         w = 1.0
-        count = brute_force((data, weight), (p, w), radius)
-        npt.assert_almost_equal(tree.count_radius(p, radius), count)
+
+        result = BallTree(data).count_radius(p, radius)
+        expect = brute_force((data, weight), (p, w), radius)
+        npt.assert_almost_equal(result, expect)
 
     @pytest.mark.parametrize("radius", radius_testvalues)
     def test_count_radius_single_weight(self, radius, rand_data_weight):
         data, weight = rand_data_weight
-        tree = BallTree(data, weight)
-
         p = data[0]
         w = weight[0]
-        count = brute_force((data, weight), (p, w), radius)
-        npt.assert_almost_equal(tree.count_radius(p, radius, weight=w), count)
+
+        result = BallTree(data, weight).count_radius(p, radius, weight=w)
+        expect = brute_force((data, weight), (p, w), radius)
+        npt.assert_almost_equal(result, expect)
 
     @pytest.mark.parametrize("radius", radius_testvalues)
     def test_count_radius_multi(self, radius, rand_data_weight):
         data, weight = rand_data_weight
-        tree = BallTree(data, weight)
+        result = BallTree(data, weight).count_radius(data, radius, weight)
 
-        count = 0.0
+        expect = 0.0
         for p, w in zip(data, weight):
-            count += brute_force((data, weight), (p, w), radius)
-        npt.assert_almost_equal(tree.count_radius(data, radius, weight), count)
+            expect += brute_force((data, weight), (p, w), radius)
+        npt.assert_almost_equal(result, expect)
 
     @pytest.mark.parametrize("radius", radius_testvalues)
     def test_dualcount_radius(self, radius, rand_data_weight):
         data, weight = rand_data_weight
         tree = BallTree(data, weight)
 
-        count = 0.0
+        expect = 0.0
         for p, w in zip(data, weight):
-            count += brute_force((data, weight), (p, w), radius)
-        npt.assert_almost_equal(tree.dualcount_radius(tree, radius), count)
+            expect += brute_force((data, weight), (p, w), radius)
+        npt.assert_almost_equal(tree.dualcount_radius(tree, radius), expect)
 
     @pytest.mark.parametrize("rmin,rmax", rminmax_testvalues)
     def test_brute_range_multi(self, rmin, rmax, rand_data_weight):
         data, weight = rand_data_weight
-        tree = BallTree(data, weight)
+        result = BallTree(data, weight).brute_range(data, (rmin, rmax), weight)
 
         count_min = 0.0
         count_max = 0.0
         for p, w in zip(data, weight):
             count_min += brute_force((data, weight), (p, w), rmin)
             count_max += brute_force((data, weight), (p, w), rmax)
-        result = [count_min, count_max - count_min]
-        npt.assert_almost_equal(tree.brute_range(data, (rmin, rmax), weight), result)
+        expect = [count_min, count_max - count_min]
+        npt.assert_almost_equal(result, expect)
 
     def test_count_range_single_radius(self, rand_data_weight):
         data, weight = rand_data_weight
-        tree = BallTree(data, weight)
 
         p = data[0]
-        expect = [tree.count_radius(p, 0.2)]
-        npt.assert_almost_equal(tree.count_range(p, 0.2), expect)
-        npt.assert_almost_equal(tree.count_range(p, [0.2]), expect)
+        expect = [BallTree(data, weight).count_radius(p, 0.2)]
+        npt.assert_almost_equal(BallTree(data, weight).count_range(p, 0.2), expect)
+        npt.assert_almost_equal(BallTree(data, weight).count_range(p, [0.2]), expect)
 
     def test_count_range_many_radii(self, rand_data_weight):
         data, weight = rand_data_weight
-        tree = BallTree(data, weight)
-
         radii = [0.1, 0.2, 0.3, 0.4]
         p = data[0]
+
+        result = BallTree(data, weight).count_range(p, radii)
+        tree = BallTree(data, weight)
         count = [tree.count_radius(p, r) for r in radii]
         expect = np.diff(count, prepend=0.0)
-        npt.assert_almost_equal(tree.count_range(p, radii), expect)
+        npt.assert_almost_equal(result, expect)
 
     @pytest.mark.parametrize("rmin,rmax", rminmax_testvalues)
     def test_count_range_single(self, rmin, rmax, rand_data_weight):
         data, weight = rand_data_weight
-        tree = BallTree(data, weight)
-
         p = data[0]
         w = weight[0]
+
+        result = BallTree(data, weight).count_range(p, (rmin, rmax), weight=w)
         count_min = brute_force((data, weight), (p, w), rmin)
         count_max = brute_force((data, weight), (p, w), rmax)
-        result = [count_min, count_max - count_min]
-        npt.assert_almost_equal(tree.count_range(p, (rmin, rmax), weight=w), result)
+        expect = [count_min, count_max - count_min]
+        npt.assert_almost_equal(result, expect)
 
     @pytest.mark.parametrize("rmin,rmax", rminmax_testvalues)
     def test_dualcount_range(self, rmin, rmax, rand_data_weight):
         data, weight = rand_data_weight
         tree = BallTree(data, weight)
+        result = tree.dualcount_range(tree, (rmin, rmax))
 
         count_min = 0.0
         count_max = 0.0
         for p, w in zip(data, weight):
             count_min += brute_force((data, weight), (p, w), rmin)
             count_max += brute_force((data, weight), (p, w), rmax)
-        result = [count_min, count_max - count_min]
-        npt.assert_almost_equal(tree.dualcount_range(tree, (rmin, rmax)), result)
+        expect = [count_min, count_max - count_min]
+        npt.assert_almost_equal(result, expect)

--- a/tests/test_balltree.py
+++ b/tests/test_balltree.py
@@ -85,15 +85,16 @@ def brute_force(data_weight, point_weight, radius):
 def brute_neighbours(data, point, k, max_dist=np.inf):
     dist = euclidean_distance(data, point)
     index = np.argsort(dist)
-    mask = dist < max_dist
+    dist = np.sort(dist)
+    mask = dist > max_dist
 
     result = np.empty((1, k), dtype=[("index", "i8"), ("distance", "f8")])
     result["index"] = -1
     result["distance"] = np.inf
 
     n = min(k, len(data))
-    result["index"][:, :n] = np.where(mask, index, -1)[:n]
-    result["distance"][:, :n] = np.where(mask, dist[index], np.inf)[:n]
+    result["index"][:, :n] = np.where(mask, -1, index)[:n]
+    result["distance"][:, :n] = np.where(mask, np.inf, dist)[:n]
     return result
 
 
@@ -264,7 +265,6 @@ class TestBallTree:
     @pytest.mark.parametrize("k", (1, 2, 10))
     def test_nearest_neighbours_multi(self, rand_data_weight, k):
         data, _ = rand_data_weight
-        point = data[0]
         result = BallTree(data).nearest_neighbours(data, k)
 
         expect = []
@@ -274,7 +274,7 @@ class TestBallTree:
         npt.assert_array_equal(result["index"], expect["index"])
         npt.assert_almost_equal(result["distance"], expect["distance"])
 
-    @pytest.mark.parametrize("max_dist", (0.02, 0.2))
+    @pytest.mark.parametrize("max_dist", (0.02, 0.2, 0.5))
     def test_nearest_neighbours_max_dist(self, rand_data_weight, max_dist):
         k = 100
         data, _ = rand_data_weight


### PR DESCRIPTION
Implemented fixed number of nearest neighbour finding, by returning the neighbour distance and index in the array from which the tree was constructed.

This required adding a new field to the Point struct, which is not used in any other algorithms and adds a small performance overhead.